### PR TITLE
Fix ECpay CheckMacValue for filter invalid character

### DIFF
--- a/woocommerce/gateways/ecpay/includes/ecpay-gateway-api.php
+++ b/woocommerce/gateways/ecpay/includes/ecpay-gateway-api.php
@@ -145,7 +145,7 @@ $("#ry-ecpay-form").submit();'
         $item_name = '';
         if (count($order->get_items())) {
             foreach ($order->get_items() as $item) {
-                $item_name .= str_replace('#', '', trim($item->get_name())) . '#';
+                $item_name .= str_replace(['#', '[', ']', ':'], '', trim($item->get_name())) . '#';
                 if (mb_strlen($item_name) > 200) {
                     break;
                 }


### PR DESCRIPTION
Filter invalid character (such as '[', ']', ':'), to fix ECpay CheckMacValue error

Reference: [ECpay FAQ](https://www.ecpay.com.tw/CascadeFAQ/CascadeFAQ_Qa?nID=1197#)